### PR TITLE
Fix issue #43 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,7 +81,12 @@ More details refer to https://github.com/gnuhpc/Kafka-zk-restapi/blob/master/doc
 See below: <<_security,'How to config security'>>
 
 === How to run
- bin/start.sh
+. tar -xvf kafka-zk-api-1.1.x-release-dist.tar
+  or
+  unzip kafka-zk-api-1.1.x-release-dist.zip
+. cd kafka-zk-api-1.1.x-release-dist
+. bin/start.sh
+
  Note: If connect to a kafka cluster that adds SASL authentication, add -Djava.security.auth.login.config=jaas.conf to JVM property.
 
 [[_security]]

--- a/docs/index.html
+++ b/docs/index.html
@@ -7818,7 +7818,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-07-01 10:18:09 +08:00
+Last updated 2019-08-28 13:13:56 CST
 </div>
 </div>
 </body>

--- a/docs/index.pdf
+++ b/docs/index.pdf
@@ -4,8 +4,8 @@
 << /Title (Kafka REST API SwaggerUI)
 /Creator (Asciidoctor PDF 1.5.0.alpha.10, based on Prawn 1.3.0)
 /Producer (Asciidoctor PDF 1.5.0.alpha.10, based on Prawn 1.3.0)
-/CreationDate (D:20190703141953+08'00')
-/ModDate (D:20190703141953+08'00')
+/CreationDate (D:20190828131748+08'00')
+/ModDate (D:20190828131748+08'00')
 >>
 endobj
 2 0 obj

--- a/src/main/resources/application-tina.yml
+++ b/src/main/resources/application-tina.yml
@@ -14,7 +14,7 @@ kafka:
 
 
 zookeeper:
-  uris: localhost:2183q
+  uris: localhost:2183
 
 jmx:
   kafka:

--- a/src/main/resources/application-tina.yml
+++ b/src/main/resources/application-tina.yml
@@ -14,7 +14,7 @@ kafka:
 
 
 zookeeper:
-  uris: localhost:2183
+  uris: localhost:2183q
 
 jmx:
   kafka:


### PR DESCRIPTION
Update create topic logic in line with native kafka. It's allowed to create topic that has . or _  with a warning message "WARNING: Due to limitations in metric names, topics with a period ('.') or underscore ('_') could collide. To avoid issues it is best to use either, but not both." 
But if a topic test.another_2 already exists, create test_another_2 is not allowed. 